### PR TITLE
Load folder files when pass recursive flag and add some useful hydras

### DIFF
--- a/hydras/cargo
+++ b/hydras/cargo
@@ -1,0 +1,10 @@
+c,Cargo,
+cn,New Project,read -p "Project name: " name; cargo new $name
+cb,Build,
+cbd,debug,cargo build
+cbr,release,cargo build --release
+ct,Test,cargo test
+cd,Build docs,cargo doc
+cp,Package Manager,
+cpa,Add,read -p "Package name: " name; cargo add $name
+cpr,Remove,read -p "Package name: " name; cargo add $name

--- a/hydras/npm
+++ b/hydras/npm
@@ -1,0 +1,6 @@
+n,NPM,
+nt,Test,npm test
+nr,Run script,read -p "Script name: " name; npm run $name
+np,Package Manager,
+npi,Install all deps,npm install
+npa,Add dependency,read -p "Package name: " name; npm install $name

--- a/hydras/pacman
+++ b/hydras/pacman
@@ -1,6 +1,6 @@
 p,Pacman,
 pi,Sync,read -p "Packages: " pkg;sudo pacman -S $pkg;
 pr,Remove,read -p "Packages: " pkg;sudo pacman -R $pkg
-pq,Install,read -p "Query: " query;pacman -Q $query
+pq,Query,read -p "Query: " query;pacman -Q $query
 pu,Upgrade system packages,sudo pacman -Syu
 pm,Refresh mirrors,sudo pacman-mirrors -c all

--- a/hydras/pacman
+++ b/hydras/pacman
@@ -1,0 +1,6 @@
+p,Pacman,
+pi,Sync,read -p "Packages: " pkg;sudo pacman -S $pkg;
+pr,Remove,read -p "Packages: " pkg;sudo pacman -R $pkg
+pq,Install,read -p "Query: " query;pacman -Q $query
+pu,Upgrade system packages,sudo pacman -Syu
+pm,Refresh mirrors,sudo pacman-mirrors -c all

--- a/hydras/systemd
+++ b/hydras/systemd
@@ -1,0 +1,7 @@
+s,Systemd,
+ss,Start Units,read -p "Units: " units; systemctl start $units
+sr,Stop Units,read -p "Units: " units; systemctl stop $units
+sl,Reload Units,read -p "Units: " units; systemctl reload $units
+se,Enable Unit,read -p "Unit name: " name; systemctl enable $name
+sd,Disable Unit,read -p "Unit name: " name; systemctl disable $name
+si,Is unit Enabled?,read -p "Unit name: " name; systemctl is-enabled $name

--- a/hydras/yarn
+++ b/hydras/yarn
@@ -1,0 +1,7 @@
+y,Yarn,
+yd,Dev,yarn dev
+yb,Build,yarn build
+yt,Test,yarn test
+yp,Package Manager,
+ypa,Add,read -p "Package name: " name; yarn add $name
+ypa,Remove,read -p "Package name: " name; yarn remove $name

--- a/main.c
+++ b/main.c
@@ -21,6 +21,12 @@ int main(int argc, char **argv)
   {
     if (strcmp(argv[i], "-r") == 0 || strcmp(argv[i], "--recursive") == 0)
     {
+      if (argv[i + 1] == NULL)
+      {
+        fprintf(stderr,"ERROR: Few arguments passed. Please pass folder name after 'recursive' flag");
+        return EXIT_FAILURE;
+      }
+
       recursive_mode = true;
       folder_name = (char *)malloc(strlen(argv[i + 1]) * sizeof(char));
       if (folder_name == NULL)

--- a/main.c
+++ b/main.c
@@ -1,15 +1,77 @@
 #include "hydra.h"
+#include "utils.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <dirent.h>
+#include <string.h>
 
-int main(int argc, char **argv) {
-  if( argc == 1 ) {
+int main(int argc, char **argv)
+{
+  if (argc == 1)
+  {
     fprintf(stderr, "Must provide at least one hydra file");
     return EXIT_FAILURE;
   }
 
-  Command* tree = NewCommand(0, 0, 0);
-  for(int i=1; i<argc; i++) LoadFile(tree, argv[i]);
+  bool recursive_mode = false;
+  char *folder_name = NULL;
+
+  for (int i = 1; i < argc; i++)
+  {
+    if (strcmp(argv[i], "-r") == 0 || strcmp(argv[i], "--recursive") == 0)
+    {
+      recursive_mode = true;
+      folder_name = (char *)malloc(strlen(argv[i + 1]) * sizeof(char));
+      if (folder_name == NULL)
+      {
+        perror("malloc failed");
+        return EXIT_FAILURE;
+      }
+      strcpy(folder_name, argv[i + 1]);
+    }
+  }
+
+  Command *tree = NewCommand(0, 0, 0);
+
+  if (recursive_mode)
+  {
+    DIR *folder;
+    struct dirent *entry;
+    int files = 0;
+
+    folder = opendir(folder_name);
+    if (folder == NULL)
+    {
+      perror("Unable to read directory");
+      return EXIT_FAILURE;
+    }
+
+    while ((entry = readdir(folder)))
+    {
+      files++;
+
+      size_t path_len = strlen(folder_name) + strlen(entry->d_name) + 1;
+      char *path = (char *)malloc(path_len * sizeof(char));
+      if (path == NULL)
+      {
+        perror("malloc failed");
+        return EXIT_FAILURE;
+      }
+
+      snprintf(path, path_len + 1, "%s/%s", folder_name, entry->d_name);
+      if (entry->d_name[0] != '.')
+        LoadFile(tree, path);
+    }
+
+    closedir(folder);
+  }
+  else
+  {
+
+    for (int i = 1; i < argc; i++)
+      LoadFile(tree, argv[i]);
+  }
 
   Start(tree);
 


### PR DESCRIPTION
Hi!
Thanks for your project. It's really useful. I 

# What's new?
### Load folder files 
Passing hydras one by one is not a good idea. So, I worked on this feature to make ```Hydra``` more effective and user-friendly.

Command example:
```terminal
hydra -r ./hydras
# Or 
hydra --recursive ./hydras
```
#### NOTE

The program reads the folder name after the ```recursive``` flag. So, You can't do something like:
```terminal
$ hydra ./hydras -r 
ERROR: Few arguments passed. Please pass folder name after 'recursive' flag
```



### Add more hydras 
I added some useful hydras for these tools:
  - [NPM](https://www.npmjs.com/) (Package manager for nodejs)
  - [Yarn](https://yarnpkg.com/) (another package manager for nodejs)
  - [Cargo](https://github.com/rust-lang/cargo) (The [Rust](https://www.rust-lang.org/) Package manager)
  - [Systemd](https://systemd.io/) (Init system  and service manager for [GNU/Linux](https://www.gnu.org/gnu/linux-and-gnu.en.html))
  - [Pacman](https://archlinux.org/pacman/pacman.8.html) (Package manager for Arch Linux)
