### PR TITLE
fix: interactive commands doesn't accept input user

### DIFF
--- a/hydra-completion.bash
+++ b/hydra-completion.bash
@@ -11,7 +11,6 @@ _hydra(){
         return
     fi
 
-    eval "$(hydra $HYDRA)"
+    eval $(hydra $HYDRA)
 }
-
-bind -x '" ":_hydra'
+bind -x '" ":_bash_stty_save=$(stty -g); stty sane; _hydra; stty "$_bash_stty_save"'


### PR DESCRIPTION
## Problem
When running interactive commands, It doesn't accept input from the user.

#### Preview
https://github.com/emad-elsaid/hydra/assets/73320969/1031049a-588c-49e8-a6bd-49e1608b07b6



## Solution
After some searches. I found this:

> Commands bound to a key are meant to be used as part of line editing. They run with the terminal in raw mode without echo, with bash expecting to handle each key press¹. Most commands expect to run with the terminal in [cooked mode](https://unix.stackexchange.com/questions/21752/what-s-the-difference-between-a-raw-and-a-cooked-device-driver), where the terminal reads one line at a time and echoes the input.
> 
> To run a command that takes over the terminal interaction, temporarily set the terminal to cooked mode.
> ```
> bind -x '"\C-p": _bash_stty_save=$(stty -g); stty sane; su dargod; stty "$_bash_stty_save"'
> ```
> Note that this may still not work perfectly, because you're doing something that bash doesn't expect. Bindings are not the right tool to run a command. To define a shortcut for a command, use an [alias](https://www.gnu.org/software/bash/manual/html_node/Aliases.html#Aliases).

**[Answer link](https://unix.stackexchange.com/a/535654)**