### PR TITLE
make: use $prefix for install, to aid in packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+prefix ?= /usr
 CCFLAGS = -O3 -Wextra -Wall
 
 hydra: hydra.o main.c
@@ -13,9 +14,9 @@ run-test: test
 	./test
 
 install: hydra
-	install -Dm755 hydra /usr/bin/hydra
-	install -Dm755 hydra-completion.bash /usr/share/hydra/hydra-completion.bash
-	cp --recursive --force hydras /usr/share/hydra/
+	install -Dm755 hydra $(DESTDIR)$(prefix)/bin/hydra
+	install -Dm755 hydra-completion.bash $(DESTDIR)$(prefix)/share/hydra/hydra-completion.bash
+	cp --recursive --force hydras $(DESTDIR)$(prefix)/share/hydra/
 
 clean:
 	rm -f *.o hydra test


### PR DESCRIPTION
Change make install to use $DESTDIR and $prefix
Set default prefix to /usr, so default behavior isn't changed

This makes packaging easier. Nix for example sets DESTDIR to
store path, and blanks prefix.

(I'm packaging this for nixpkgs)